### PR TITLE
Build docker images with branch name intact.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,13 @@
 set -ex
 
 # LOCAL_REGISTRY="registry.dev.appgoto.com"
-LOCAL_REGISTRY="${LOCAL_REGISTRY:-registry.dev.appgoto.com}"
+# LOCAL_REGISTRY="${LOCAL_REGISTRY:-registry.dev.appgoto.com}"
+LOCAL_REGISTRY="${LOCAL_REGISTRY:-buildregistry.localdomain}"
 
+GIT_BRNCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_SHA=$(git rev-parse HEAD | cut -c 1-8)
 
-IMAGE="${LOCAL_REGISTRY}/gfs-renderer:latest-$GIT_SHA"
+IMAGE="${LOCAL_REGISTRY}/gfs-renderer:${GIT_BRNCH}-${GIT_SHA}"
 LATEST_IMAGE="${LOCAL_REGISTRY}/gfs-renderer:latest"
 
 docker build -t $IMAGE -f Dockerfile.server .


### PR DESCRIPTION
This push script should also tag images with branch name so we know what it was built and pushed from.